### PR TITLE
Allow `by` to use vector of values

### DIFF
--- a/R/descriptive-utils.R
+++ b/R/descriptive-utils.R
@@ -23,7 +23,7 @@ describe <- function(data, by = NULL, ...){
   if (is.null(enexpr(by))){
     summarise(data, ...)
   } else {
-    summarise(group_by(data, {{ by }}), ...)
+    summarise(group_by(data, across({{ by }})), ..., .groups = 'drop')
   }
   
 }
@@ -71,15 +71,15 @@ describe <- function(data, by = NULL, ...){
 describe_across <- function(data, variables, functions, by = NULL, pivot = FALSE){
   
   if (!is.null(enexpr(by))){
-    data <- group_by(data, {{ by }})
+    data <- group_by(data, across({{ by }}))
   }
   
   if (!pivot){
     results <- data %>% 
-      summarise(across({{ variables }}, functions))
+      summarise(across({{ variables }}, functions), .groups = 'drop')
   } else {
     results <- data %>% 
-      summarise(across({{ variables }}, functions, .names = "{.fn}_____{.col}")) %>%
+      summarise(across({{ variables }}, functions, .names = "{.fn}_____{.col}"), .groups = 'drop') %>%
       tidyr::pivot_longer(cols = contains('_____'),
                           names_to = c('.value', 'variable'),
                           names_sep = '_____')

--- a/vignettes/exploration.Rmd
+++ b/vignettes/exploration.Rmd
@@ -49,6 +49,19 @@ describe(data = faithfulfaces, by = face_sex,
          avg = mean(faithful), stdev = sd(faithful))
 ```
 
+The `by` argument may be a vector of variables.
+In this case, the chosen variables are grouped by the combination of the `by` variables.
+For example, in the following we group the `time` variable in `vizverb` by both `task` and `response`.
+```{r}
+describe(vizverb, by = c(task, response),
+         avg = mean(time),
+         median = median(time),
+         iqr = IQR(time),
+         stdev = sd(time)
+)
+```
+
+
 # Multiple summary functions to multiple variables
 
 It would be tedious and repetitive to use `describe` as above if wanted to apply the same set of summary statistic functions to a set of variables.
@@ -80,6 +93,8 @@ describe_across(faithfulfaces,
                 pivot = TRUE
 )
 ```
+
+As in the case of `describe`, the `by` argument can be a vector of variables.
 
 # Dealing with missing values with `_xna`
 


### PR DESCRIPTION
In `describe` and `describe_across`, replace {{by}} by across({{by}})

This will allow `by` to be a vector and we can group by multiple
variables.

Add examples of using vector `by` in vignettes

Fixes: Issue #1